### PR TITLE
fix(s3): use data-uri parser output, instead of relying on a regular expression

### DIFF
--- a/services/s3-helper.js
+++ b/services/s3-helper.js
@@ -18,12 +18,10 @@ function S3Helper() {
       // Create the S3 client.
       let s3Bucket = new AWS.S3({ params: { Bucket: process.env.S3_BUCKET }});
       let parsed = parseDataUri(rawData);
-      let base64Image = rawData.replace(/^data:(image|application)\/\w+;base64,/, '');
 
       let data = {
         Key: filename,
-        Body: new Buffer(base64Image, 'base64'),
-        ContentEncoding: 'base64',
+        Body: parsed.data,
         ContentDisposition: 'inline',
         ContentType: parsed.mimeType,
         ACL: 'public-read'


### PR DESCRIPTION
The regular expression will break when:
- Parameters are used on the MediaType
- mimeType are not either application/ or image/
- The data uri is not using base64 encoding

For instance:
`text/plain;charset=utf8,Hello%20World` is a valid data-uri.
